### PR TITLE
Add docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Based on PoCs found in https://github.com/bambulab/BambuStudio/issues/1536#issue
 * [go2rtc](https://github.com/AlexxIT/go2rtc/releases)
 
 ### Usage
-* Update [camera-stream.py](https://github.com/synman/bambu-go2rtc/blob/main/camera-stream.py) with your Bambu printer's `hostname` and `access_code`
+* `PRINTER_ADDRESS=192.168.1.100 PRINTER_ACCESS_CODE=12345678 ./go2rtc_linux_arm64` with your Bambu printer's `hostname` or IP address and your respective `access_code` for LAN Only Mode
 * Use the included shellscripts ([mac](https://github.com/synman/bambu-go2rtc/blob/main/run-on-mac.sh) / [linux arm](https://github.com/synman/bambu-go2rtc/blob/main/run-on-linux-arm.sh)) as reference and make the necessary adjustments for your environment
 * Live Stream - [http://localhost:1984/api/stream.mjpeg?src=bambu_camera](http://localhost:1984/api/stream.mjpeg?src=bambu_camera)
 * Single Frame - [http://localhost:1984/api/frame.jpeg?src=bambu_camera](http://localhost:1984/api/frame.jpeg?src=bambu_camera)

--- a/camera-stream.py
+++ b/camera-stream.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import struct
 import os
@@ -7,8 +7,8 @@ import ssl
 import time
 
 username = 'bblp'
-access_code = ''
-hostname = ''
+access_code = os.environ['PRINTER_ACCESS_CODE']
+hostname = os.environ['PRINTER_ADDRESS']
 port = 6000
 
 MAX_CONNECT_ATTEMPTS = 12

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '3.8'
+services:
+  bambu-go2rtc:
+    image: "docker.io/alexxit/go2rtc"
+    restart: "unless-stopped"
+    # These are the configuration options if a
+    # traefik setup is in place.
+    #labels:
+    #  - "traefik.enable=true"
+    #  - "traefik.http.routers.bambu-go2rtc.rule=Host(`bambu-webcam.example.com`)"
+    #  - "traefik.http.routers.bambu-go2rtc.entrypoints=websecure"
+    #  - "traefik.http.routers.bambu-go2rtc.tls=true"
+    #  - "traefik.http.services.bambu-go2rtc.loadbalancer.server.port=1984"
+    #  # This is enabling automatic LE certificate generation
+    #  - "traefik.http.routers.bambu-go2rtc.tls.certresolver=leresolver"
+    #  - "traefik.http.routers.bambu-go2rtc.tls.domains[0].main=bambu-webcam.example.com"
+    #  # To enable basic auth uncomment and generate approprioate password using htpasswd
+    #  #- "traefik.http.routers.bambu-go2rtc.middlewares=auth-$COMPOSE_PROJECT_NAME"
+    #  #- "traefik.http.middlewares.auth-bambu-go2rtc.basicauth.users=bambu:$$HTPASSWD_FORMAT_PASSWORD"
+    ports:
+      - "1984:1984"
+    environment:
+      # Remember these values are defaults that can
+      # be overriden by a .env file. Putting sensitive
+      # data in a docker-compose.yml is less secure.
+      # See env-example for the exact format.
+      PRINTER_ADDRESS: ${PRINTER_ADDRESS:-192.168.1.100}
+      PRINTER_ACCESS_CODE: ${PRINTER_ACCESS_CODE:-12345679}
+    volumes:
+      - "./go2rtc.yaml:/config/go2rtc.yaml"
+      - "./camera-stream.py:/config/camera-stream.py"
+
+#networks:
+#  default:
+#    name: traefik

--- a/env-example
+++ b/env-example
@@ -1,0 +1,5 @@
+# Run:
+# cp env-example .env
+# then change values in .env
+PRINTER_ADDRESS=10.1.1.10
+PRINTER_ACCESS_CODE=123456789


### PR DESCRIPTION
This contribution introduces a pre-configured docker-compose.yml file to the repository, streamlining the setup process. Some minor tweaks were necessary to ensure seamless compatibility with the official Docker image and to enhance the protection of the access_code against potential security risks.

I've had a smooth experience with the docker-compose setup, and integrating it with Home Assistant was a breeze.

Changing shebang to allow for /usr/local/bin/python3, too
-> This is needed to use official docker.io/alexxit/go2rtc docker
image.
Add new syntax on calling the go2rtc to README.md
Pulling access credentials from environment
Adding docker compose file
Add env-example